### PR TITLE
Add --hot flag to enable dev server hot reloading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,9 +229,11 @@ const build = (): Promise<number> => {
 const dev = async ({
   host: inputHost,
   port: inputPort,
+  hot: hotReloading = false,
 }: {
   host?: string;
   port?: string;
+  hot?: boolean;
 }): Promise<number> => {
   const port = Number(inputPort) || 8000;
   const host = inputHost || "127.0.0.1";
@@ -270,7 +272,7 @@ const dev = async ({
           },
           clientLogLevel: "none",
           injectClient: false,
-          hot: false,
+          hot: hotReloading,
           inline: false,
         });
 


### PR DESCRIPTION
Yet another CLI flag for the dev command! This time to enable hot reloading, which I have found to be quite handy when trying things out.

From the commit:
> The underlying Webpack Dev Server supports hot reloading, and the
feature is hardcoded to false here. This changeset keeps that default
behaviour while allowing to enable the feature with the `--hot` command
line flag (takes no additional arguments).