### PR TITLE
Updates generated index.ts file

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -369,18 +369,18 @@ const init = async ({
         return fs.writeFileSync(
           path.join(root, "src", "index.ts"),
           `import toConfigPageName from "roamjs-components/util/toConfigPageName";
-  import runExtension from "roamjs-components/util/runExtension";
-  import { createConfigObserver } from "roamjs-components/components/ConfigPage";
-  
-  const extensionId = "${extensionName}";
-  const CONFIG = toConfigPageName(ID);
-  runExtension({
-    extensionId, 
-    run: () => {
-      createConfigObserver({ title: CONFIG, config: { tabs: [] } });
-    },
-    unload: () => {},
-  });
+import runExtension from "roamjs-components/util/runExtension";
+import { createConfigObserver } from "roamjs-components/components/ConfigPage";
+
+const extensionId = "${extensionName}";
+const CONFIG = toConfigPageName(extensionId);
+export default runExtension({
+  extensionId, 
+  run: () => {
+    createConfigObserver({ title: CONFIG, config: { tabs: [] } });
+  },
+  unload: () => {},
+});
   `
         );
       },


### PR DESCRIPTION
There were a couple of touch ups I needed to make before index.ts would build and I could properly use the new extension.
1. There was some additional whitespace
2. ID was undefined (I assume it needs to be extensionId)
3. The file needs a default export in order for Roam to execute the extension.