### PR TITLE
Disable enforcing fully specified file names for modules

### DIFF
--- a/src/common/getBaseConfig.ts
+++ b/src/common/getBaseConfig.ts
@@ -182,6 +182,12 @@ const getBaseConfig = (): Promise<
             limit: 100000,
           },
         },
+        {
+          test: /\.m?js$/,
+          resolve: {
+            fullySpecified: false,
+          },
+        },
       ],
     },
   });


### PR DESCRIPTION
https://stackoverflow.com/questions/69427025/programmatic-webpack-jest-esm-cant-resolve-module-without-js-file-exten